### PR TITLE
lock fabric loader version in packwiz pack

### DIFF
--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -10,4 +10,4 @@ preserve = false
 
 [versions]
 minecraft = "1.20.4"
-fabric = "latest"
+fabric = "0.15.1"

--- a/server.toml
+++ b/server.toml
@@ -3,7 +3,7 @@ mc_version = "1.20.4"
 
 [jar]
 type = "fabric"
-loader = "latest"
+loader = "0.15.2"
 installer = "latest"
 
 [variables]


### PR DESCRIPTION
want to lock this in right now to avoid dumb inconsistency issues down the line. it has already caused one while testing this!