### PR TITLE
Add falseresync's itemuserestrictor mod

### DIFF
--- a/server.toml
+++ b/server.toml
@@ -434,6 +434,11 @@ repo = "TheEpicBlock/not-flying"
 tag = "1.0.1"
 asset = "first"
 
+[[mods]]
+type = "modrinth"
+id = "itemuserestrictor"
+version = "ZelxnHUS"
+
 [worlds.modfest-1-20.download]
 type = "ghrel"
 repo = "ModFest/modfest-1-20"


### PR DESCRIPTION
Primary usage for myself: restricting Flutter and Flounder prismarine diamond activation. 